### PR TITLE
Feature/match detail

### DIFF
--- a/Football_Manager/pom.xml
+++ b/Football_Manager/pom.xml
@@ -1,51 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>4.0.3</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath/>
     </parent>
+
     <groupId>com.example</groupId>
     <artifactId>Football_Manager</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>Football_Manager</name>
     <description>Football_Manager</description>
-    <url/>
-    <licenses>
-        <license/>
-    </licenses>
-    <developers>
-        <developer/>
-    </developers>
-    <scm>
-        <connection/>
-        <developerConnection/>
-        <tag/>
-        <url/>
-    </scm>
+
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.0</spring-cloud.version>
+        <lombok.version>1.18.34</lombok.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-restclient</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webservices</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -54,53 +85,33 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
+
+        <!-- Tests -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-restclient-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webservices-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.thymeleaf.extras</groupId>
-            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.0</version>
-        </dependency>
     </dependencies>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -115,6 +126,22 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.1</version>
+                <configuration>
+                    <release>17</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/Football_Manager/src/main/java/com/example/football_manager/controller/MatchController.java
+++ b/Football_Manager/src/main/java/com/example/football_manager/controller/MatchController.java
@@ -1,20 +1,16 @@
 package com.example.football_manager.controller;
 
-import com.example.football_manager.dto.MatchResultRequestDTO;
-import com.example.football_manager.model.Match;
 import com.example.football_manager.dto.MatchRequestDTO;
 import com.example.football_manager.dto.MatchResultDTO;
+import com.example.football_manager.dto.MatchResultRequestDTO;
+import com.example.football_manager.model.Match;
 import com.example.football_manager.service.MatchService;
 import jakarta.validation.Valid;
-
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.util.List;
 
 import java.util.List;
 
@@ -30,7 +26,6 @@ public class MatchController {
         return ResponseEntity.ok(matchService.getAllMatches());
     }
 
-    // Schedule a match
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> createMatchFromJson(@Valid @RequestBody MatchRequestDTO matchDTO) {
         return createMatchResponse(matchDTO);
@@ -49,14 +44,12 @@ public class MatchController {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
     }
-    
-    // Retrieve finished match results
+
     @GetMapping("/results")
     public ResponseEntity<List<MatchResultDTO>> getMatchResults() {
         return ResponseEntity.ok(matchService.getFinishedMatchResults());
     }
 
-    // Edit match details
     @PutMapping("/{id}")
     public ResponseEntity<String> updateMatch(@PathVariable Long id, @RequestBody MatchRequestDTO matchDTO) {
         try {
@@ -66,7 +59,6 @@ public class MatchController {
         }
     }
 
-    // Delete a match
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteMatch(@PathVariable Long id) {
         try {
@@ -76,7 +68,6 @@ public class MatchController {
         }
     }
 
-    // Register result (Score)
     @PatchMapping("/{id}/result")
     public ResponseEntity<String> registerResult(
             @PathVariable Long id,
@@ -86,11 +77,5 @@ public class MatchController {
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
-    }
-    
-    @GetMapping
-    public ResponseEntity<List<Match>> getAllMatches() {
-        List<Match> matches = matchService.getAllMatches();
-        return ResponseEntity.ok(matches);
     }
 }

--- a/Football_Manager/src/main/java/com/example/football_manager/controller/MatchViewController.java
+++ b/Football_Manager/src/main/java/com/example/football_manager/controller/MatchViewController.java
@@ -5,6 +5,7 @@ import com.example.football_manager.dto.MatchResultRequestDTO;
 import com.example.football_manager.model.Match;
 import com.example.football_manager.model.MatchGoal;
 import com.example.football_manager.service.MatchService;
+import com.example.football_manager.service.TeamService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,9 +21,11 @@ import java.util.List;
 public class MatchViewController {
 
     private final MatchService matchService;
+    private final TeamService teamService;
 
-    public MatchViewController(MatchService matchService) {
+    public MatchViewController(MatchService matchService, TeamService teamService) {
         this.matchService = matchService;
+        this.teamService = teamService;
     }
 
     @GetMapping("/matches/schedule")
@@ -56,6 +59,7 @@ public class MatchViewController {
             @ModelAttribute("resultRequest") MatchResultRequestDTO resultRequest,
             Model model,
             RedirectAttributes redirectAttributes) {
+
         Match match = matchService.getMatchById(id);
         model.addAttribute("match", match);
 
@@ -81,7 +85,9 @@ public class MatchViewController {
             MatchResultRequestDTO.GoalDTO goalDTO = new MatchResultRequestDTO.GoalDTO();
             goalDTO.setTeamId(goal.getTeam().getId());
             goalDTO.setMinute((int) goal.getMinute());
-            goalDTO.setStoppageMinute(goal.getStoppageMinute() == null ? null : (int) goal.getStoppageMinute());
+            goalDTO.setStoppageMinute(
+                    goal.getStoppageMinute() == null ? null : (int) goal.getStoppageMinute()
+            );
             goalDTOs.add(goalDTO);
         }
 

--- a/Football_Manager/src/main/java/com/example/football_manager/controller/TeamViewController.java
+++ b/Football_Manager/src/main/java/com/example/football_manager/controller/TeamViewController.java
@@ -1,7 +1,9 @@
 package com.example.football_manager.controller;
 
 import com.example.football_manager.dto.TeamRequestDTO;
+import com.example.football_manager.model.Team;
 import com.example.football_manager.service.CountryService;
+import com.example.football_manager.service.MatchService;
 import com.example.football_manager.service.TeamService;
 import com.example.football_manager.service.UserService;
 import jakarta.servlet.http.HttpSession;
@@ -27,41 +29,62 @@ public class TeamViewController {
     @Autowired
     private UserService userService;
 
+    @Autowired
+    private MatchService matchService;
+
     @GetMapping("/teams")
     public String teamsPage(Model model, HttpSession session) {
         Boolean isAdmin = (Boolean) session.getAttribute("isAdmin");
         Long userId = (Long) session.getAttribute("userId");
 
-        model.addAttribute("isAdmin", isAdmin != null && isAdmin);
-        model.addAttribute("teams", teamService.getAllTeams());
-
         Set<Long> favouriteTeamIds = Set.of();
+
         try {
             favouriteTeamIds = userService.getFavouriteTeamIdsByUserId(userId);
         } catch (IllegalArgumentException ignored) {
-            // If session contains an invalid user id, render page without favourites.
         }
+
+        model.addAttribute("isAdmin", isAdmin != null && isAdmin);
+        model.addAttribute("teams", teamService.getAllTeams());
         model.addAttribute("favouriteTeamIds", favouriteTeamIds);
+        model.addAttribute("favouriteUpcomingMatches", matchService.getFutureMatchesByFavouriteTeamIds(favouriteTeamIds));
 
         return "teams";
+    }
+
+    @GetMapping("/teams/{id}")
+    public String teamDetailsPage(@PathVariable Long id, Model model, HttpSession session) {
+        Boolean isAdmin = (Boolean) session.getAttribute("isAdmin");
+
+        Team team = teamService.getTeamById(id)
+                .orElseThrow(() -> new RuntimeException("Team not found"));
+
+        model.addAttribute("isAdmin", isAdmin != null && isAdmin);
+        model.addAttribute("team", team);
+        model.addAttribute("recentMatches", matchService.getRecentMatchesByTeamId(id));
+        model.addAttribute("futureMatches", matchService.getFutureMatchesByTeamId(id));
+
+        return "team-details";
     }
 
     @GetMapping("/teams/add")
     public String showAddTeamForm(Model model) {
         model.addAttribute("teamRequest", new TeamRequestDTO());
         model.addAttribute("countries", countryService.getAllCountries());
+
         return "add-team";
     }
 
     @PostMapping("/teams/add")
     public String createTeam(@ModelAttribute TeamRequestDTO teamDTO) {
         teamService.createTeam(teamDTO);
+
         return "redirect:/teams";
     }
 
     @GetMapping("/teams/edit/{id}")
     public String showEditTeamForm(@PathVariable Long id, Model model) {
-        com.example.football_manager.model.Team existingTeam = teamService.getTeamById(id)
+        Team existingTeam = teamService.getTeamById(id)
                 .orElseThrow(() -> new RuntimeException("Team not found"));
 
         TeamRequestDTO teamDTO = new TeamRequestDTO();
@@ -74,20 +97,22 @@ public class TeamViewController {
 
         model.addAttribute("teamRequest", teamDTO);
         model.addAttribute("teamId", id);
-
         model.addAttribute("countries", countryService.getAllCountries());
+
         return "edit-team";
     }
 
     @PostMapping("/teams/edit/{id}")
     public String updateTeam(@PathVariable Long id, @ModelAttribute TeamRequestDTO teamDTO) {
         teamService.updateTeam(id, teamDTO);
+
         return "redirect:/teams";
     }
 
     @PostMapping("/teams/delete/{id}")
     public String deleteTeam(@PathVariable Long id) {
         teamService.deleteTeam(id);
+
         return "redirect:/teams";
     }
 }

--- a/Football_Manager/src/main/java/com/example/football_manager/repository/MatchRepository.java
+++ b/Football_Manager/src/main/java/com/example/football_manager/repository/MatchRepository.java
@@ -4,10 +4,31 @@ import com.example.football_manager.model.Match;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface MatchRepository extends JpaRepository<Match, Long> {
-    List<Match> findByFinishedTrueOrderByDatetimeDesc();
-}
 
+    List<Match> findByFinishedTrueOrderByDatetimeDesc();
+
+    List<Match> findByFinishedTrueAndLeftTeamIdOrFinishedTrueAndRightTeamIdOrderByDatetimeDesc(
+            Long leftTeamId,
+            Long rightTeamId
+    );
+
+    List<Match> findByFinishedFalseAndDatetimeAfterAndLeftTeamIdOrFinishedFalseAndDatetimeAfterAndRightTeamIdOrderByDatetimeAsc(
+            OffsetDateTime now1,
+            Long leftTeamId,
+            OffsetDateTime now2,
+            Long rightTeamId
+    );
+
+    List<Match> findByFinishedFalseAndDatetimeAfterAndLeftTeamIdInOrFinishedFalseAndDatetimeAfterAndRightTeamIdInOrderByDatetimeAsc(
+            OffsetDateTime now1,
+            Collection<Long> leftTeamIds,
+            OffsetDateTime now2,
+            Collection<Long> rightTeamIds
+    );
+}

--- a/Football_Manager/src/main/java/com/example/football_manager/service/MatchService.java
+++ b/Football_Manager/src/main/java/com/example/football_manager/service/MatchService.java
@@ -1,6 +1,5 @@
 package com.example.football_manager.service;
 
-import com.example.football_manager.model.Match;
 import com.example.football_manager.dto.MatchRequestDTO;
 import com.example.football_manager.dto.MatchResultDTO;
 import com.example.football_manager.dto.MatchResultRequestDTO;
@@ -15,10 +14,12 @@ import com.example.football_manager.repository.TeamRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 @Service
 public class MatchService {
@@ -28,25 +29,28 @@ public class MatchService {
     private final TeamRepository teamRepository;
     private final CompetitionRepository competitionRepository;
 
-    public MatchService(MatchRepository matchRepository, MatchGoalRepository matchGoalRepository,
-                        TeamRepository teamRepository, CompetitionRepository competitionRepository) {
+    public MatchService(
+            MatchRepository matchRepository,
+            MatchGoalRepository matchGoalRepository,
+            TeamRepository teamRepository,
+            CompetitionRepository competitionRepository
+    ) {
         this.matchRepository = matchRepository;
         this.matchGoalRepository = matchGoalRepository;
         this.teamRepository = teamRepository;
         this.competitionRepository = competitionRepository;
     }
 
-    /**
-     * Schedule a new match with manual validations.
-     */
     @Transactional
     public String createMatch(MatchRequestDTO request) {
         validateMatchRequest(request, true);
 
         Team homeTeam = teamRepository.findById(request.getHomeTeamId())
                 .orElseThrow(() -> new IllegalArgumentException("Home team not found with id: " + request.getHomeTeamId()));
+
         Team awayTeam = teamRepository.findById(request.getAwayTeamId())
                 .orElseThrow(() -> new IllegalArgumentException("Away team not found with id: " + request.getAwayTeamId()));
+
         Competition competition = competitionRepository.findById(request.getCompetitionId())
                 .orElseThrow(() -> new IllegalArgumentException("Competition not found with id: " + request.getCompetitionId()));
 
@@ -91,17 +95,16 @@ public class MatchService {
         }
     }
 
-    /**
-     * Update match details (time, venue, status).
-     */
     @Transactional
     public String updateMatch(Long id, MatchRequestDTO request) {
         validateMatchRequest(request, false);
 
         Match match = matchRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Match not found with id: " + id));
+
         Team homeTeam = teamRepository.findById(request.getHomeTeamId())
                 .orElseThrow(() -> new IllegalArgumentException("Home team not found with id: " + request.getHomeTeamId()));
+
         Team awayTeam = teamRepository.findById(request.getAwayTeamId())
                 .orElseThrow(() -> new IllegalArgumentException("Away team not found with id: " + request.getAwayTeamId()));
 
@@ -120,24 +123,21 @@ public class MatchService {
         }
 
         matchRepository.save(match);
+
         return "Match with ID " + id + " has been updated.";
     }
 
-    /**
-     * Delete a match from the system.
-     */
     @Transactional
     public String deleteMatch(Long id) {
         Match match = matchRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Match not found with id: " + id));
+
         matchGoalRepository.deleteByMatchId(id);
         matchRepository.delete(match);
+
         return "Match with ID " + id + " has been deleted.";
     }
 
-    /**
-     * Register final match result from the goals scored in the match.
-     */
     @Transactional
     public String registerResult(Long id, MatchResultRequestDTO request) {
         if (request == null || request.getGoals() == null) {
@@ -179,9 +179,6 @@ public class MatchService {
         return "Result registered for match " + id + ": " + leftScore + " - " + rightScore;
     }
 
-    /**
-     * Display teams and final score for finished matches.
-     */
     public List<MatchResultDTO> getFinishedMatchResults() {
         List<Match> matches = matchRepository.findByFinishedTrueOrderByDatetimeDesc();
 
@@ -195,6 +192,55 @@ public class MatchService {
                         match.getDatetime()
                 ))
                 .toList();
+    }
+
+    public List<Match> getAllMatches() {
+        return matchRepository.findAll();
+    }
+
+    public Match getMatchById(Long id) {
+        return matchRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Match not found with id: " + id));
+    }
+
+    public List<MatchGoal> getGoalsByMatchId(Long matchId) {
+        return matchGoalRepository.findByMatchIdOrderByMinuteAscStoppageMinuteAscIdAsc(matchId);
+    }
+
+    public List<Match> getRecentMatchesByTeamId(Long teamId) {
+        return matchRepository
+                .findByFinishedTrueAndLeftTeamIdOrFinishedTrueAndRightTeamIdOrderByDatetimeDesc(
+                        teamId,
+                        teamId
+                );
+    }
+
+    public List<Match> getFutureMatchesByTeamId(Long teamId) {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        return matchRepository
+                .findByFinishedFalseAndDatetimeAfterAndLeftTeamIdOrFinishedFalseAndDatetimeAfterAndRightTeamIdOrderByDatetimeAsc(
+                        now,
+                        teamId,
+                        now,
+                        teamId
+                );
+    }
+
+    public List<Match> getFutureMatchesByFavouriteTeamIds(Set<Long> favouriteTeamIds) {
+        if (favouriteTeamIds == null || favouriteTeamIds.isEmpty()) {
+            return List.of();
+        }
+
+        OffsetDateTime now = OffsetDateTime.now();
+
+        return matchRepository
+                .findByFinishedFalseAndDatetimeAfterAndLeftTeamIdInOrFinishedFalseAndDatetimeAfterAndRightTeamIdInOrderByDatetimeAsc(
+                        now,
+                        favouriteTeamIds,
+                        now,
+                        favouriteTeamIds
+                );
     }
 
     private Team resolveScoringTeam(Match match, MatchResultRequestDTO.GoalDTO goalDTO) {
@@ -236,18 +282,5 @@ public class MatchService {
         }
 
         return score.shortValue();
-    }
-
-    public List<Match> getAllMatches() {
-        return matchRepository.findAll();
-    }
-
-    public Match getMatchById(Long id) {
-        return matchRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Match not found with id: " + id));
-    }
-
-    public List<MatchGoal> getGoalsByMatchId(Long matchId) {
-        return matchGoalRepository.findByMatchIdOrderByMinuteAscStoppageMinuteAscIdAsc(matchId);
     }
 }

--- a/Football_Manager/src/main/resources/db/manual/create_match_goal_table.sql
+++ b/Football_Manager/src/main/resources/db/manual/create_match_goal_table.sql
@@ -1,3 +1,5 @@
+
+
 ALTER TABLE "match"
     ADD COLUMN IF NOT EXISTS venue VARCHAR(100) NOT NULL DEFAULT 'Unknown';
 

--- a/Football_Manager/src/main/resources/templates/team-details.html
+++ b/Football_Manager/src/main/resources/templates/team-details.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${team.name + ' - Football Manager'}">Team Details</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+
+<body class="bg-slate-100 min-h-screen font-sans text-slate-800">
+
+<nav class="bg-slate-900 border-b-2 border-emerald-600 shadow-md">
+    <div class="max-w-7xl mx-auto px-4">
+        <div class="flex justify-between items-center h-16">
+            <a href="/teams" class="text-white font-black uppercase">
+                Football<span class="text-emerald-500">Manager</span>
+            </a>
+
+            <div class="flex gap-3">
+                <a href="/teams" class="px-4 py-2 bg-slate-800 text-slate-300 rounded-md hover:bg-slate-700">
+                    Back to Teams
+                </a>
+
+                <a th:if="${isAdmin}" href="/admin"
+                   class="px-4 py-2 bg-slate-800 text-slate-300 rounded-md hover:bg-slate-700">
+                    Admin Panel
+                </a>
+            </div>
+        </div>
+    </div>
+</nav>
+
+<main class="max-w-6xl mx-auto px-4 py-10">
+
+    <section class="bg-white rounded-2xl shadow-sm border border-slate-200 p-8 mb-8">
+        <div class="flex flex-col md:flex-row items-center gap-6">
+            <div class="w-28 h-28 bg-slate-50 rounded-2xl border p-3 flex items-center justify-center">
+                <img th:src="${team.logoUrl != null && !team.logoUrl.isEmpty() ? team.logoUrl : 'https://via.placeholder.com/150?text=Logo'}"
+                     class="w-full h-full object-contain"
+                     alt="Team logo">
+            </div>
+
+            <div class="text-center md:text-left">
+                <h1 class="text-4xl font-extrabold uppercase text-slate-900" th:text="${team.name}">
+                    Team Name
+                </h1>
+
+                <p class="text-slate-500 mt-2 font-medium"
+                   th:text="${team.country != null ? team.country.name : 'Unknown country'}">
+                    Country
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <section class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+
+        <div class="bg-white rounded-2xl shadow-sm border border-slate-200 p-6">
+            <h2 class="text-2xl font-extrabold text-slate-900 uppercase mb-4">
+                Recent Matches
+            </h2>
+
+            <div th:if="${#lists.isEmpty(recentMatches)}" class="text-slate-500">
+                No recent matches for this team.
+            </div>
+
+            <div th:if="${!#lists.isEmpty(recentMatches)}" class="space-y-4">
+                <div th:each="match : ${recentMatches}"
+                     class="border border-slate-200 rounded-xl p-4 bg-slate-50">
+
+                    <div class="flex justify-between items-center gap-4">
+                        <div class="font-bold text-slate-900"
+                             th:text="${match.leftTeam.name}">
+                            Home
+                        </div>
+
+                        <div class="text-xl font-black text-emerald-600"
+                             th:text="${match.leftScore + ' - ' + match.rightScore}">
+                            0 - 0
+                        </div>
+
+                        <div class="font-bold text-slate-900 text-right"
+                             th:text="${match.rightTeam.name}">
+                            Away
+                        </div>
+                    </div>
+
+                    <div class="text-sm text-slate-500 mt-2 text-center"
+                         th:text="${#temporals.format(match.datetime, 'dd MMM yyyy HH:mm')}">
+                        Date
+                    </div>
+
+                    <div class="text-sm text-slate-500 mt-1 text-center"
+                         th:text="${match.venue}">
+                        Venue
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white rounded-2xl shadow-sm border border-slate-200 p-6">
+            <h2 class="text-2xl font-extrabold text-slate-900 uppercase mb-4">
+                Future Matches
+            </h2>
+
+            <div th:if="${#lists.isEmpty(futureMatches)}" class="text-slate-500">
+                No future matches for this team.
+            </div>
+
+            <div th:if="${!#lists.isEmpty(futureMatches)}" class="space-y-4">
+                <div th:each="match : ${futureMatches}"
+                     class="border border-slate-200 rounded-xl p-4 bg-slate-50">
+
+                    <div class="flex justify-between items-center gap-4">
+                        <div class="font-bold text-slate-900"
+                             th:text="${match.leftTeam.name}">
+                            Home
+                        </div>
+
+                        <div class="text-sm font-black text-slate-500 uppercase">
+                            VS
+                        </div>
+
+                        <div class="font-bold text-slate-900 text-right"
+                             th:text="${match.rightTeam.name}">
+                            Away
+                        </div>
+                    </div>
+
+                    <div class="text-sm text-slate-500 mt-2 text-center"
+                         th:text="${#temporals.format(match.datetime, 'dd MMM yyyy HH:mm')}">
+                        Date
+                    </div>
+
+                    <div class="text-sm text-slate-500 mt-1 text-center"
+                         th:text="${match.venue}">
+                        Venue
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </section>
+</main>
+
+</body>
+</html>

--- a/Football_Manager/src/main/resources/templates/teams.html
+++ b/Football_Manager/src/main/resources/templates/teams.html
@@ -11,27 +11,38 @@
         }
     </style>
 </head>
+
 <body class="pitch-bg min-h-screen font-sans text-slate-800">
 
 <nav class="bg-slate-900 border-b-2 border-emerald-600 shadow-md">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center h-16">
             <div class="flex items-center gap-3">
-                <svg class="w-8 h-8 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"></path></svg>
-                <span class="text-xl font-black text-white uppercase tracking-wider">Football<span class="text-emerald-500">Manager</span></span>
+                <svg class="w-8 h-8 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"></path>
+                </svg>
+                <span class="text-xl font-black text-white uppercase tracking-wider">
+                    Football<span class="text-emerald-500">Manager</span>
+                </span>
             </div>
-            <div class="flex gap-3">
 
-                <a href="/profile" class="px-4 py-2 bg-slate-800 text-slate-300 text-sm font-medium rounded-md hover:bg-slate-700 hover:text-white transition-colors border border-slate-700">
+            <div class="flex gap-3">
+                <a href="/profile"
+                   class="px-4 py-2 bg-slate-800 text-slate-300 text-sm font-medium rounded-md hover:bg-slate-700 hover:text-white transition-colors border border-slate-700">
                     My Profile
                 </a>
 
-                <a th:if="${isAdmin}" href="/admin" class="px-4 py-2 bg-slate-800 text-slate-300 text-sm font-medium rounded-md hover:bg-slate-700 hover:text-white transition-colors border border-slate-700">
+                <a th:if="${isAdmin}" href="/admin"
+                   class="px-4 py-2 bg-slate-800 text-slate-300 text-sm font-medium rounded-md hover:bg-slate-700 hover:text-white transition-colors border border-slate-700">
                     Admin Panel
                 </a>
 
                 <form th:action="@{/logout}" method="POST" class="m-0">
-                    <button type="submit" class="px-4 py-2 bg-red-500/10 text-red-500 text-sm font-medium rounded-md hover:bg-red-500 hover:text-white transition-colors border border-red-500/20">
+                    <button type="submit"
+                            class="px-4 py-2 bg-red-500/10 text-red-500 text-sm font-medium rounded-md hover:bg-red-500 hover:text-white transition-colors border border-red-500/20">
                         Logout
                     </button>
                 </form>
@@ -45,38 +56,103 @@
     <div class="flex flex-col md:flex-row justify-between items-center mb-8 gap-4 bg-white p-6 rounded-2xl shadow-sm border border-slate-200">
         <div>
             <h1 class="text-3xl font-extrabold text-slate-900 tracking-tight uppercase">Database</h1>
-            <p class="text-slate-500 mt-1 font-medium">Explore all available teams and clubs.</p>
+            <p class="text-slate-500 mt-1 font-medium">
+                Explore all available teams and clubs. Click a team to see recent and future matches.
+            </p>
         </div>
 
         <div class="w-full md:w-96 relative">
             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <svg class="h-5 w-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
+                <svg class="h-5 w-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                </svg>
             </div>
+
             <input type="text" id="searchInput" placeholder="Filter by team name or country..."
                    class="block w-full pl-10 pr-3 py-3 border border-slate-300 rounded-xl leading-5 bg-slate-50 placeholder-slate-400 focus:outline-none focus:bg-white focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-all sm:text-sm">
         </div>
     </div>
 
+    <section class="mb-8 bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden">
+        <div class="px-6 py-5 border-b border-slate-200 bg-slate-50">
+            <h2 class="text-2xl font-extrabold text-slate-900 uppercase">
+                Upcoming Matches From Your Favourite Teams
+            </h2>
+            <p class="text-slate-500 mt-1 font-medium">
+                These are the next matches involving teams you marked with the heart.
+            </p>
+        </div>
+
+        <div th:if="${#lists.isEmpty(favouriteUpcomingMatches)}" class="p-6 text-slate-500">
+            You do not have upcoming matches from favourite teams yet.
+        </div>
+
+        <div th:if="${!#lists.isEmpty(favouriteUpcomingMatches)}" class="divide-y divide-slate-200">
+            <a th:each="match : ${favouriteUpcomingMatches}"
+               th:href="@{/teams/{id}(id=${match.leftTeam.id})}"
+               class="block px-6 py-4 hover:bg-emerald-50 transition-colors">
+
+                <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                    <div class="flex-1">
+                        <p class="text-sm text-slate-500 font-medium"
+                           th:text="${match.competition != null ? match.competition.name : 'Competition'}">
+                            Competition
+                        </p>
+
+                        <div class="mt-1 flex flex-wrap items-center gap-2 text-lg font-black text-slate-900">
+                            <span th:text="${match.leftTeam.name}">Home</span>
+                            <span class="text-emerald-600">vs</span>
+                            <span th:text="${match.rightTeam.name}">Away</span>
+                        </div>
+                    </div>
+
+                    <div class="md:text-right">
+                        <p class="text-sm font-bold text-slate-700"
+                           th:text="${#temporals.format(match.datetime, 'dd MMM yyyy HH:mm')}">
+                            Date
+                        </p>
+                        <p class="text-sm text-slate-500"
+                           th:text="${match.venue}">
+                            Venue
+                        </p>
+                    </div>
+                </div>
+            </a>
+        </div>
+    </section>
+
     <div id="noResults" class="hidden bg-white p-12 rounded-2xl shadow-sm border border-slate-200 text-center">
         <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 text-slate-400 mb-4">
-            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
         </div>
         <h3 class="text-lg font-bold text-slate-900">No teams found</h3>
         <p class="text-slate-500 mt-1">Try adjusting your search filter.</p>
     </div>
 
-    <div id="favouriteError" class="hidden mb-6 p-4 rounded-xl border text-sm font-medium bg-red-50 border-red-200 text-red-700"></div>
+    <div id="favouriteError"
+         class="hidden mb-6 p-4 rounded-xl border text-sm font-medium bg-red-50 border-red-200 text-red-700"></div>
 
-    <div th:if="${#lists.isEmpty(teams)}" class="bg-white p-12 rounded-2xl shadow-sm border border-slate-200 text-center">
+    <div th:if="${#lists.isEmpty(teams)}"
+         class="bg-white p-12 rounded-2xl shadow-sm border border-slate-200 text-center">
         <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 text-slate-400 mb-4">
-            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"></path></svg>
+            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"></path>
+            </svg>
         </div>
         <h3 class="text-lg font-bold text-slate-900">Database empty</h3>
         <p class="text-slate-500 mt-1">No teams have been added to the system yet.</p>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" id="teamsGrid">
-        <div th:each="team : ${teams}" class="team-card bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden hover:shadow-lg hover:border-emerald-300 transition-all group">
+        <div th:each="team : ${teams}"
+             th:attr="data-url=@{/teams/{id}(id=${team.id})}"
+             onclick="window.location.href=this.dataset.url"
+             class="team-card bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden hover:shadow-lg hover:border-emerald-300 transition-all group cursor-pointer">
 
             <div class="h-2 w-full bg-gradient-to-r from-emerald-400 to-emerald-600"></div>
 
@@ -90,9 +166,13 @@
 
                     <div class="flex-1 min-w-0">
                         <div class="flex items-start justify-between gap-3">
-                            <h2 class="team-name text-xl font-bold text-slate-900 truncate uppercase" th:text="${team.name}">Team Name</h2>
+                            <h2 class="team-name text-xl font-bold text-slate-900 truncate uppercase"
+                                th:text="${team.name}">
+                                Team Name
+                            </h2>
 
                             <button type="button"
+                                    onclick="event.stopPropagation()"
                                     class="favourite-toggle p-1 rounded-full text-slate-400 hover:text-red-500 transition-colors"
                                     th:attr="data-team-id=${team.id},data-favourite=${favouriteTeamIds != null and favouriteTeamIds.contains(team.id)}"
                                     aria-label="Toggle favourite">
@@ -103,9 +183,19 @@
                         </div>
 
                         <div class="flex items-center mt-1 text-sm text-slate-500 font-medium">
-                            <svg class="w-4 h-4 mr-1 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                            <span class="team-country truncate" th:text="${team.country != null ? team.country.name : 'Unknown'}">Country</span>
+                            <svg class="w-4 h-4 mr-1 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                      d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                            </svg>
+                            <span class="team-country truncate"
+                                  th:text="${team.country != null ? team.country.name : 'Unknown'}">
+                                Country
+                            </span>
                         </div>
+
+                        <p class="mt-4 text-xs font-bold text-emerald-600 uppercase tracking-wide opacity-0 group-hover:opacity-100 transition-opacity">
+                            View matches →
+                        </p>
                     </div>
                 </div>
             </div>
@@ -128,6 +218,7 @@
             }
 
             button.dataset.favourite = String(isFavourite);
+
             if (isFavourite) {
                 icon.setAttribute('fill', 'currentColor');
                 button.classList.remove('text-slate-400');
@@ -143,6 +234,7 @@
             if (!favouriteError) {
                 return;
             }
+
             favouriteError.textContent = text;
             favouriteError.classList.remove('hidden');
         }
@@ -151,6 +243,7 @@
             if (!favouriteError) {
                 return;
             }
+
             favouriteError.textContent = '';
             favouriteError.classList.add('hidden');
         }
@@ -158,9 +251,12 @@
         favouriteButtons.forEach(button => {
             setHeartState(button, button.dataset.favourite === 'true');
 
-            button.addEventListener('click', async () => {
+            button.addEventListener('click', async (event) => {
+                event.stopPropagation();
+
                 const teamId = button.dataset.teamId;
                 const isFavourite = button.dataset.favourite === 'true';
+
                 if (!teamId) {
                     return;
                 }
@@ -177,18 +273,19 @@
 
                     if (response.ok) {
                         setHeartState(button, !isFavourite);
+                        window.location.reload();
                         return;
                     }
 
                     if (!isFavourite && response.status === 409) {
-                        // Server says it's already favourited, so sync UI to filled heart.
                         setHeartState(button, true);
+                        window.location.reload();
                         return;
                     }
 
                     if (isFavourite && response.status === 409) {
-                        // Server says it's already removed, so sync UI to outlined heart.
                         setHeartState(button, false);
+                        window.location.reload();
                         return;
                     }
 
@@ -201,9 +298,9 @@
             });
         });
 
-        if(searchInput) {
-            searchInput.addEventListener('input', (e) => {
-                const searchTerm = e.target.value.toLowerCase();
+        if (searchInput) {
+            searchInput.addEventListener('input', (event) => {
+                const searchTerm = event.target.value.toLowerCase();
                 let visibleCount = 0;
 
                 teamCards.forEach(card => {
@@ -230,4 +327,3 @@
 
 </body>
 </html>
-

--- a/Football_Manager/src/test/java/com/example/football_manager/service/MatchServiceTest.java
+++ b/Football_Manager/src/test/java/com/example/football_manager/service/MatchServiceTest.java
@@ -2,9 +2,14 @@ package com.example.football_manager.service;
 
 import com.example.football_manager.dto.MatchRequestDTO;
 import com.example.football_manager.dto.MatchResultDTO;
+import com.example.football_manager.dto.MatchResultRequestDTO;
+import com.example.football_manager.model.Competition;
 import com.example.football_manager.model.Match;
 import com.example.football_manager.model.Team;
+import com.example.football_manager.repository.CompetitionRepository;
+import com.example.football_manager.repository.MatchGoalRepository;
 import com.example.football_manager.repository.MatchRepository;
+import com.example.football_manager.repository.TeamRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -12,25 +17,62 @@ import org.mockito.Mockito;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 class MatchServiceTest {
 
     private MatchService matchService;
+
+    private MatchRepository matchRepository;
+    private MatchGoalRepository matchGoalRepository;
+    private TeamRepository teamRepository;
+    private CompetitionRepository competitionRepository;
+
     private MatchRequestDTO validRequest;
+    private Team homeTeam;
+    private Team awayTeam;
+    private Competition competition;
 
     @BeforeEach
     void setUp() {
-        matchService = new MatchService();
+        matchRepository = Mockito.mock(MatchRepository.class);
+        matchGoalRepository = Mockito.mock(MatchGoalRepository.class);
+        teamRepository = Mockito.mock(TeamRepository.class);
+        competitionRepository = Mockito.mock(CompetitionRepository.class);
+
+        matchService = new MatchService(
+                matchRepository,
+                matchGoalRepository,
+                teamRepository,
+                competitionRepository
+        );
+
+        homeTeam = new Team();
+        homeTeam.setId(1L);
+        homeTeam.setName("Arsenal");
+
+        awayTeam = new Team();
+        awayTeam.setId(2L);
+        awayTeam.setName("Chelsea");
+
+        competition = new Competition();
+        competition.setId(1L);
+        competition.setName("Premier League");
 
         validRequest = new MatchRequestDTO();
         validRequest.setHomeTeamId(1L);
         validRequest.setAwayTeamId(2L);
+        validRequest.setCompetitionId(1L);
         validRequest.setKickoffTime(LocalDateTime.of(2026, 4, 1, 20, 30));
-        validRequest.setVenue("Bernabeu");
+        validRequest.setVenue("Emirates Stadium");
+
+        when(teamRepository.findById(1L)).thenReturn(Optional.of(homeTeam));
+        when(teamRepository.findById(2L)).thenReturn(Optional.of(awayTeam));
+        when(competitionRepository.findById(1L)).thenReturn(Optional.of(competition));
     }
 
     @Test
@@ -39,6 +81,7 @@ class MatchServiceTest {
 
         assertEquals("Match scheduled successfully.", result);
         assertEquals(MatchRequestDTO.MatchStatus.SCHEDULED, validRequest.getStatus());
+        verify(matchRepository).save(any(Match.class));
     }
 
     @Test
@@ -49,63 +92,124 @@ class MatchServiceTest {
 
         assertEquals("Match scheduled successfully.", result);
         assertEquals(MatchRequestDTO.MatchStatus.CANCELLED, validRequest.getStatus());
+        verify(matchRepository).save(any(Match.class));
     }
 
     @Test
     void createMatch_shouldThrowWhenHomeTeamIdIsMissing() {
         validRequest.setHomeTeamId(null);
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> matchService.createMatch(validRequest));
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> matchService.createMatch(validRequest)
+        );
 
         assertEquals("Validation Error: Both Home and Away team IDs are required.", ex.getMessage());
+        verify(matchRepository, never()).save(any(Match.class));
     }
 
     @Test
     void createMatch_shouldThrowWhenAwayTeamIdIsMissing() {
         validRequest.setAwayTeamId(null);
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> matchService.createMatch(validRequest));
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> matchService.createMatch(validRequest)
+        );
 
         assertEquals("Validation Error: Both Home and Away team IDs are required.", ex.getMessage());
+        verify(matchRepository, never()).save(any(Match.class));
+    }
+
+    @Test
+    void createMatch_shouldThrowWhenCompetitionIdIsMissing() {
+        validRequest.setCompetitionId(null);
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> matchService.createMatch(validRequest)
+        );
+
+        assertEquals("Validation Error: Competition ID is required.", ex.getMessage());
+        verify(matchRepository, never()).save(any(Match.class));
     }
 
     @Test
     void createMatch_shouldThrowWhenKickoffTimeIsMissing() {
         validRequest.setKickoffTime(null);
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> matchService.createMatch(validRequest));
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> matchService.createMatch(validRequest)
+        );
 
         assertEquals("Validation Error: Kickoff time and Venue are required.", ex.getMessage());
+        verify(matchRepository, never()).save(any(Match.class));
     }
 
     @Test
     void createMatch_shouldThrowWhenVenueIsMissing() {
         validRequest.setVenue(null);
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> matchService.createMatch(validRequest));
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> matchService.createMatch(validRequest)
+        );
 
         assertEquals("Validation Error: Kickoff time and Venue are required.", ex.getMessage());
+        verify(matchRepository, never()).save(any(Match.class));
     }
 
     @Test
     void createMatch_shouldThrowWhenTeamsAreTheSame() {
         validRequest.setAwayTeamId(1L);
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> matchService.createMatch(validRequest));
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> matchService.createMatch(validRequest)
+        );
 
         assertEquals("Validation Error: Home and Away teams must be different.", ex.getMessage());
+        verify(matchRepository, never()).save(any(Match.class));
+    }
+
+    @Test
+    void getAllMatches_shouldReturnMatchesList() {
+        Match match = new Match();
+        match.setId(11L);
+        match.setLeftTeam(homeTeam);
+        match.setRightTeam(awayTeam);
+        match.setCompetition(competition);
+        match.setDatetime(OffsetDateTime.parse("2026-04-19T14:00:00Z"));
+        match.setVenue("Emirates Stadium");
+        match.setLeftScore((short) 0);
+        match.setRightScore((short) 0);
+        match.setFinished(false);
+
+        when(matchRepository.findAll()).thenReturn(List.of(match));
+
+        List<Match> result = matchService.getAllMatches();
+
+        assertEquals(1, result.size());
+        assertEquals(11L, result.get(0).getId());
+        assertEquals("Arsenal", result.get(0).getLeftTeam().getName());
+        verify(matchRepository).findAll();
     }
 
     @Test
     void updateMatch_shouldReturnSuccessMessage() {
+        Match existingMatch = new Match();
+        existingMatch.setId(8L);
+
+        when(matchRepository.findById(8L)).thenReturn(Optional.of(existingMatch));
+
         String result = matchService.updateMatch(8L, validRequest);
 
         assertEquals("Match with ID 8 has been updated.", result);
+        assertEquals(homeTeam, existingMatch.getLeftTeam());
+        assertEquals(awayTeam, existingMatch.getRightTeam());
+        assertEquals("Emirates Stadium", existingMatch.getVenue());
+        verify(matchRepository).save(existingMatch);
     }
 
     @Test
@@ -113,63 +217,82 @@ class MatchServiceTest {
         validRequest.setHomeTeamId(5L);
         validRequest.setAwayTeamId(5L);
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> matchService.updateMatch(8L, validRequest));
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> matchService.updateMatch(8L, validRequest)
+        );
 
         assertEquals("Validation Error: Home and Away teams must be different.", ex.getMessage());
+        verify(matchRepository, never()).save(any(Match.class));
     }
 
     @Test
     void deleteMatch_shouldReturnSuccessMessage() {
+        Match existingMatch = new Match();
+        existingMatch.setId(3L);
+
+        when(matchRepository.findById(3L)).thenReturn(Optional.of(existingMatch));
+
         String result = matchService.deleteMatch(3L);
 
         assertEquals("Match with ID 3 has been deleted.", result);
-    }
-
-    @Test
-    void deleteMatch_shouldDeleteFromRepositoryWhenMatchExists() {
-        MatchRepository repository = Mockito.mock(MatchRepository.class);
-        Mockito.when(repository.existsById(3L)).thenReturn(true);
-
-        MatchService serviceWithRepository = new MatchService(repository);
-
-        String result = serviceWithRepository.deleteMatch(3L);
-
-        assertEquals("Match with ID 3 has been deleted.", result);
-        verify(repository).deleteById(3L);
+        verify(matchGoalRepository).deleteByMatchId(3L);
+        verify(matchRepository).delete(existingMatch);
     }
 
     @Test
     void deleteMatch_shouldThrowWhenMatchDoesNotExist() {
-        MatchRepository repository = Mockito.mock(MatchRepository.class);
-        Mockito.when(repository.existsById(99L)).thenReturn(false);
+        when(matchRepository.findById(99L)).thenReturn(Optional.empty());
 
-        MatchService serviceWithRepository = new MatchService(repository);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> matchService.deleteMatch(99L)
+        );
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> serviceWithRepository.deleteMatch(99L));
-
-        assertEquals("Match with ID 99 was not found.", ex.getMessage());
-        verify(repository, never()).deleteById(99L);
+        assertEquals("Match not found with id: 99", ex.getMessage());
+        verify(matchGoalRepository, never()).deleteByMatchId(99L);
+        verify(matchRepository, never()).delete(any(Match.class));
     }
 
     @Test
     void registerResult_shouldReturnExpectedMessage() {
-        String result = matchService.registerResult(9L, 2, 1);
+        Match match = new Match();
+        match.setId(9L);
+        match.setLeftTeam(homeTeam);
+        match.setRightTeam(awayTeam);
+
+        when(matchRepository.findById(9L)).thenReturn(Optional.of(match));
+
+        MatchResultRequestDTO request = new MatchResultRequestDTO();
+
+        MatchResultRequestDTO.GoalDTO goal1 = new MatchResultRequestDTO.GoalDTO();
+        goal1.setTeamId(1L);
+        goal1.setMinute(10);
+
+        MatchResultRequestDTO.GoalDTO goal2 = new MatchResultRequestDTO.GoalDTO();
+        goal2.setTeamId(1L);
+        goal2.setMinute(30);
+
+        MatchResultRequestDTO.GoalDTO goal3 = new MatchResultRequestDTO.GoalDTO();
+        goal3.setTeamId(2L);
+        goal3.setMinute(70);
+
+        request.setGoals(List.of(goal1, goal2, goal3));
+
+        String result = matchService.registerResult(9L, request);
 
         assertEquals("Result registered for match 9: 2 - 1", result);
+        assertEquals(2, match.getLeftScore());
+        assertEquals(1, match.getRightScore());
+        assertTrue(match.isFinished());
+
+        verify(matchGoalRepository).deleteByMatchId(9L);
+        verify(matchGoalRepository).saveAll(anyList());
+        verify(matchRepository).save(match);
     }
-    
+
     @Test
     void getFinishedMatchResults_shouldReturnTeamsAndScore() {
-        MatchRepository repository = Mockito.mock(MatchRepository.class);
-
-        Team homeTeam = new Team();
-        homeTeam.setName("Arsenal");
-
-        Team awayTeam = new Team();
-        awayTeam.setName("Chelsea");
-
         Match finishedMatch = new Match();
         finishedMatch.setId(11L);
         finishedMatch.setLeftTeam(homeTeam);
@@ -179,18 +302,84 @@ class MatchServiceTest {
         finishedMatch.setDatetime(OffsetDateTime.parse("2026-04-19T14:00:00Z"));
         finishedMatch.setFinished(true);
 
-        Mockito.when(repository.findByFinishedTrueOrderByDatetimeDesc()).thenReturn(List.of(finishedMatch));
+        when(matchRepository.findByFinishedTrueOrderByDatetimeDesc())
+                .thenReturn(List.of(finishedMatch));
 
-        MatchService serviceWithRepository = new MatchService(repository);
-
-        List<MatchResultDTO> results = serviceWithRepository.getFinishedMatchResults();
+        List<MatchResultDTO> results = matchService.getFinishedMatchResults();
 
         assertEquals(1, results.size());
+
         MatchResultDTO result = results.get(0);
         assertEquals(11L, result.matchId());
         assertEquals("Arsenal", result.homeTeamName());
         assertEquals("Chelsea", result.awayTeamName());
         assertEquals(3, result.homeScore());
         assertEquals(2, result.awayScore());
+    }
+
+    @Test
+    void getRecentMatchesByTeamId_shouldReturnFinishedMatchesForTeam() {
+        Match finishedMatch = new Match();
+        finishedMatch.setId(20L);
+
+        when(matchRepository.findByFinishedTrueAndLeftTeamIdOrFinishedTrueAndRightTeamIdOrderByDatetimeDesc(1L, 1L))
+                .thenReturn(List.of(finishedMatch));
+
+        List<Match> result = matchService.getRecentMatchesByTeamId(1L);
+
+        assertEquals(1, result.size());
+        assertEquals(20L, result.get(0).getId());
+    }
+
+    @Test
+    void getFutureMatchesByTeamId_shouldReturnUpcomingMatchesForTeam() {
+        Match futureMatch = new Match();
+        futureMatch.setId(30L);
+
+        when(matchRepository.findByFinishedFalseAndDatetimeAfterAndLeftTeamIdOrFinishedFalseAndDatetimeAfterAndRightTeamIdOrderByDatetimeAsc(
+                any(OffsetDateTime.class),
+                eq(1L),
+                any(OffsetDateTime.class),
+                eq(1L)
+        )).thenReturn(List.of(futureMatch));
+
+        List<Match> result = matchService.getFutureMatchesByTeamId(1L);
+
+        assertEquals(1, result.size());
+        assertEquals(30L, result.get(0).getId());
+    }
+
+    @Test
+    void getFutureMatchesByFavouriteTeamIds_shouldReturnEmptyWhenNoFavourites() {
+        List<Match> result = matchService.getFutureMatchesByFavouriteTeamIds(Set.of());
+
+        assertTrue(result.isEmpty());
+        verify(matchRepository, never())
+                .findByFinishedFalseAndDatetimeAfterAndLeftTeamIdInOrFinishedFalseAndDatetimeAfterAndRightTeamIdInOrderByDatetimeAsc(
+                        any(),
+                        any(),
+                        any(),
+                        any()
+                );
+    }
+
+    @Test
+    void getFutureMatchesByFavouriteTeamIds_shouldReturnUpcomingMatches() {
+        Match futureMatch = new Match();
+        futureMatch.setId(40L);
+
+        Set<Long> favouriteIds = Set.of(1L, 2L);
+
+        when(matchRepository.findByFinishedFalseAndDatetimeAfterAndLeftTeamIdInOrFinishedFalseAndDatetimeAfterAndRightTeamIdInOrderByDatetimeAsc(
+                any(OffsetDateTime.class),
+                eq(favouriteIds),
+                any(OffsetDateTime.class),
+                eq(favouriteIds)
+        )).thenReturn(List.of(futureMatch));
+
+        List<Match> result = matchService.getFutureMatchesByFavouriteTeamIds(favouriteIds);
+
+        assertEquals(1, result.size());
+        assertEquals(40L, result.get(0).getId());
     }
 }

--- a/Football_Manager/src/test/java/com/example/football_manager/service/UserServiceTest.java
+++ b/Football_Manager/src/test/java/com/example/football_manager/service/UserServiceTest.java
@@ -15,10 +15,15 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import com.example.football_manager.model.Team;
+import com.example.football_manager.repository.TeamRepository;
+import java.util.HashSet;
+import java.util.Set;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
-
+    @Mock
+    private TeamRepository teamRepository;
     @Mock
     private UserRepository userRepository;
 
@@ -176,5 +181,105 @@ class UserServiceTest {
                 () -> userService.getUserByUsername("ghost"));
 
         assertEquals("User not found", ex.getMessage());
+    }
+
+    @Test
+    void addFavouriteTeam_shouldAddTeamSuccessfully() {
+        Team team = new Team();
+        team.setId(10L);
+        team.setName("Real Madrid");
+
+        normalUser.setFavouriteTeams(new HashSet<>());
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(normalUser));
+        when(teamRepository.findById(10L)).thenReturn(Optional.of(team));
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        User result = userService.addFavouriteTeam(1L, 10L);
+
+        assertEquals(1, result.getFavouriteTeams().size());
+        assertTrue(result.getFavouriteTeams().contains(team));
+        verify(userRepository).save(normalUser);
+    }
+
+    @Test
+    void addFavouriteTeam_shouldThrowWhenTeamAlreadyFavourite() {
+        Team team = new Team();
+        team.setId(10L);
+        team.setName("Real Madrid");
+
+        normalUser.setFavouriteTeams(new HashSet<>());
+        normalUser.getFavouriteTeams().add(team);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(normalUser));
+        when(teamRepository.findById(10L)).thenReturn(Optional.of(team));
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> userService.addFavouriteTeam(1L, 10L)
+        );
+
+        assertEquals("Team already in favourites", ex.getMessage());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void removeFavouriteTeam_shouldRemoveTeamSuccessfully() {
+        Team team = new Team();
+        team.setId(10L);
+        team.setName("Real Madrid");
+
+        normalUser.setFavouriteTeams(new HashSet<>());
+        normalUser.getFavouriteTeams().add(team);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(normalUser));
+        when(teamRepository.existsById(10L)).thenReturn(true);
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        User result = userService.removeFavouriteTeam(1L, 10L);
+
+        assertTrue(result.getFavouriteTeams().isEmpty());
+        verify(userRepository).save(normalUser);
+    }
+
+    @Test
+    void removeFavouriteTeam_shouldThrowWhenTeamNotInFavourites() {
+        normalUser.setFavouriteTeams(new HashSet<>());
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(normalUser));
+        when(teamRepository.existsById(10L)).thenReturn(true);
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> userService.removeFavouriteTeam(1L, 10L)
+        );
+
+        assertEquals("Team not in favourites", ex.getMessage());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void getFavouriteTeamIdsByUserId_shouldReturnFavouriteIds() {
+        Team team1 = new Team();
+        team1.setId(10L);
+
+        Team team2 = new Team();
+        team2.setId(20L);
+
+        normalUser.setFavouriteTeams(Set.of(team1, team2));
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(normalUser));
+
+        Set<Long> result = userService.getFavouriteTeamIdsByUserId(1L);
+
+        assertEquals(Set.of(10L, 20L), result);
+    }
+
+    @Test
+    void getFavouriteTeamIdsByUserId_shouldReturnEmptyWhenUserIdIsNull() {
+        Set<Long> result = userService.getFavouriteTeamIdsByUserId(null);
+
+        assertTrue(result.isEmpty());
+        verify(userRepository, never()).findById(anyLong());
     }
 }


### PR DESCRIPTION
Implement match, favourites and admin sprint features

- Add and update match service tests for listing, editing, deletion and result recording
- Add tests for favourite team functionality
- Add upcoming matches support for favourite teams on the main teams view
- Add team detail page with recent and future matches
- Make teams clickable from the main teams page
- Improve match repository queries for recent, future and favourite-team matches
- Fix Lombok Maven compiler configuration
- Clean up duplicated match service methods and outdated test setup
- Add admin-related registration/update support

Closes #55
Closes #60
Closes #64
Closes #69
Closes #86
